### PR TITLE
refactor: make base module http property readonly

### DIFF
--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -10,7 +10,8 @@ import LoginResponse from 'types/login-response.interface';
  * @extends {Base}
  */
 export default class Auth extends Base {
-  tokenProvider: TokenProvider;
+  private tokenProvider: TokenProvider;
+  private baseUrl = '/auth';
 
   constructor(http: HttpClient, tokenProvider: TokenProvider) {
     super(http);
@@ -26,7 +27,7 @@ export default class Auth extends Base {
    */
   async login(email: string, password: string): Promise<LoginResponse> {
     const { data } = await this.http.request<LoginResponse>({
-      url: '/auth',
+      url: this.baseUrl,
       method: 'POST',
       data: {
         email,
@@ -46,7 +47,7 @@ export default class Auth extends Base {
    */
   async logout(): Promise<void> {
     await this.http.request({
-      url: 'auth/logout',
+      url: `${this.baseUrl}/logout`,
       method: 'PUT',
     });
 
@@ -61,7 +62,7 @@ export default class Auth extends Base {
    */
   async forgotPassword(email: string): Promise<void> {
     await this.http.request({
-      url: '/auth/forgot',
+      url: `${this.baseUrl}/forgot`,
       method: 'POST',
       data: {
         email
@@ -78,7 +79,7 @@ export default class Auth extends Base {
    */
   async resetPassword(newPassword: string, verifyPassword: string, code: string): Promise<void> {
     await this.http.request({
-      url: `/auth/reset/${code}`,
+      url: `${this.baseUrl}/reset/${code}`,
       method: 'POST',
       data: {
         // eslint-disable-next-line @typescript-eslint/camelcase

--- a/src/modules/base.ts
+++ b/src/modules/base.ts
@@ -1,7 +1,7 @@
 import HttpClient from "core/http-client";
 
 export default class Base {
-  http: HttpClient;
+  readonly http: HttpClient;
 
   constructor(httpClient: HttpClient) {
     this.http = httpClient;

--- a/src/modules/base.ts
+++ b/src/modules/base.ts
@@ -1,7 +1,7 @@
 import HttpClient from "core/http-client";
 
 export default class Base {
-  readonly http: HttpClient;
+  protected readonly http: HttpClient;
 
   constructor(httpClient: HttpClient) {
     this.http = httpClient;

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -2,36 +2,50 @@ import Config from '../env';
 import KanvasSDK from '../src/index';
 
 const client = new KanvasSDK(Config);
+const email = 'demo@dealerappcenter.com';
+const password = 'nosenose';
+const unregisterdEmail = 'no-one@dealerappcenter.com';
+const wrongPassword = 'password';
 
-
-describe('check auth works', () => {
-  test('can log in', async() => {
-    const data = await client.auth.login('demo@dealerappcenter.com', 'nosenose');
-    
-    expect(data.token).toBeDefined();
+describe('Perform Auth module Test', () => {
+  describe('Can user be authenticated', () => {
+    test('User can login', async() => {
+      const data = await client.auth.login(email, password);
+      
+      expect(data.token).toBeDefined();
+    });
   });
 
-  test('log in fails email', async() => {
-    const { errors: { data } } = await client.auth.login('', 'nosenose').catch(error => error);
+  describe('User failed authentication', () => {
+    test('User does not provide an email.', async() => {
+      const { errors: { data } } = await client.auth.login('', password).catch(error => error);
 
-    expect(data[0].email[0]).toEqual('The email field is required.');
-  });
+      expect(data[0].email[0]).toEqual('The email field is required.');
+    });
 
-  test('log in fails password', async() => {
-    const { errors: { data } } = await client.auth.login('demo@dealerappcenter.com', '').catch(error => error);
+    test('User does not provide a password', async() => {
+      const { errors: { data } } = await client.auth.login(email, '').catch(error => error);
 
-    expect(data[0].password[0]).toEqual('The password field is required.');
-  });
+      expect(data[0].password[0]).toEqual('The password field is required.');
+    });
 
-  test('user not found', async() => {
-    const { errors: { message } } = await client.auth.login('no-one@email.com', 'nosenose').catch(error => error);
+    test('User does not provide a password', async() => {
+      const { errors: { data } } = await client.auth.login('', '').catch(error => error);
 
-    expect(message).toEqual('No User Found');
-  });
+      expect(data[0].email[0]).toEqual('The email field is required.');
+      expect(data[0].password[0]).toEqual('The password field is required.');
+    });
 
-  test('invalid email or password', async() => {
-    const { errors: { message } } = await client.auth.login('demo@dealerappcenter.com', 'password').catch(error => error);
+    test('User does not provide valid credentials', async() => {
+      const { errors: { message } } = await client.auth.login(unregisterdEmail, password).catch(error => error);
 
-    expect(message).toEqual('Invalid email or password.');
+      expect(message).toEqual('No User Found');
+    });
+
+    test('User provides wrong password', async() => {
+      const { errors: { message } } = await client.auth.login(email, wrongPassword).catch(error => error);
+
+      expect(message).toEqual('Invalid email or password.');
+    });
   });
 });


### PR DESCRIPTION
### Description

This PR adds the private `baseUrl` property to the `Auth` module.

### Why
- Refactor:
  - Make `http` property in `Base` module readonly.
  - Add `private baseUrl = '/auth'` in `Auth` module.

### How

This change is introduced to have consistency across modules and improve updating calls if base URL changes.

#### Checklist
- [x] The branch is updated with the main branch.
- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I added/changed environment variables and notified my partners.