### PR TITLE
refactor: add baseUrl to base module and check value is set

### DIFF
--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -11,10 +11,9 @@ import LoginResponse from 'types/login-response.interface';
  */
 export default class Auth extends Base {
   private tokenProvider: TokenProvider;
-  private baseUrl = '/auth';
 
   constructor(http: HttpClient, tokenProvider: TokenProvider) {
-    super(http);
+    super(http, '/auth');
     this.tokenProvider = tokenProvider;
   }
 

--- a/src/modules/base.ts
+++ b/src/modules/base.ts
@@ -2,8 +2,14 @@ import HttpClient from "core/http-client";
 
 export default class Base {
   protected readonly http: HttpClient;
+  protected readonly baseUrl: string;
 
-  constructor(httpClient: HttpClient) {
+  constructor(httpClient: HttpClient, baseUrl: string) {
     this.http = httpClient;
+    this.baseUrl = baseUrl;
+
+    if (!this.baseUrl) {
+      throw new Error('baseUrl has to be defined.');
+    }
   }
 }

--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -18,11 +18,8 @@ interface CreatedUsed {
  * @description Kanvas Users Module
  */
 export default class Users extends Base {
-  private baseUrl: string
-
   constructor(http: HttpClient) {
-    super(http);
-    this.baseUrl = '/users';
+    super(http, '/users');
   }
 
   /**

--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -109,7 +109,7 @@ export default class Users extends Base {
    * @param {number} userId 
    * @returns {Promise<UserInterface>} - Deleted user
    */
-  async delete(userId: number): Promise<UserInterface> {
+  async remove(userId: number): Promise<UserInterface> {
     const { data } = await this.http.request<UserInterface>({
       method: 'DELETE',
       url: `${this.baseUrl}/${userId}`,


### PR DESCRIPTION
### Description

This PR addresses the use of `baseUrl` as part of the Base module.

### Why
- Refactor:
  - Make `http` property in `Base` module protected.
  - Add `protected readonly baseUrl: string` in `Base` module.
  - Verify that `baseUrl` has a value set.
  - Refactor `Auth` and `Users` modules to use new baseUrl implementation.

#### Checklist
- [x] The branch is updated with the main branch.
- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I added/changed environment variables and notified my partners.