### PR TITLE
feat: add user create params interface

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -7,7 +7,7 @@
  */
 import Module from 'modules/module';
 import HttpClient from 'core/http-client';
-import { UserInterface, CreatedUser } from 'types/user.interface';
+import { UserInterface, CreateUserParams, CreatedUser } from 'types/user.interface';
 
 /**
  * @description Kanvas Users Module
@@ -22,7 +22,7 @@ export default class Users extends Module<UserInterface> {
    * @param {<T>} userData - Data to be posted for creating the user.
    * @returns {Promise<T>} - Newly created user.
    */
-  async create(userData: UserInterface): Promise<UserInterface> {
+  async create(userData: UserInterface | CreateUserParams): Promise<UserInterface> {
     const { data } = await this.http.request<CreatedUser>({
       method: 'POST',
       url: this.baseUrl,

--- a/src/types/user.interface.ts
+++ b/src/types/user.interface.ts
@@ -60,8 +60,11 @@ export interface UserInterface {
   locale: string;
   roles: string;
   states: string;
-  password?: string;
-  verify_password?: string;
+}
+
+export interface CreateUserParams extends Pick<UserInterface, 'email'> {
+  password: string;
+  verify_password: string;
 }
 
 export interface CreatedUser {


### PR DESCRIPTION
### Description

When creating a user the only required fields are `email`, `password`, and `verify_password`.
Create method was causing conflict by relying on `UserInterface` which lists every field assignable to user.

- Feat: Add new `CreateUserParams` interface, picking `email` from primary `UserInterface`.
- Feat: Add `CreateUserParams` as an option for the `create` method for users.